### PR TITLE
Enabling parsing of variable length optional header in PE file

### DIFF
--- a/src/debug/pe/pe.go
+++ b/src/debug/pe/pe.go
@@ -19,6 +19,45 @@ type DataDirectory struct {
 	Size           uint32
 }
 
+// Have to define optionalHeader32Base and optionalHeader64Base structs to keep api checker tool happy.
+// The api checker tool doesn't understand promoted fields, so if these structs are embeded in 
+// OptionalHeader32 and OptionalHeader64 structs, it throws an error.
+// As a result, defining these unexported structs to be used by binary.Read() (ref. symbol.go)
+// Also defined unexported init methods on OptionalHeader32 and OptionalHeader64 structs to initialize
+// them from corresponding base structs
+type optionalHeader32Base struct {
+	Magic                       uint16
+	MajorLinkerVersion          uint8
+	MinorLinkerVersion          uint8
+	SizeOfCode                  uint32
+	SizeOfInitializedData       uint32
+	SizeOfUninitializedData     uint32
+	AddressOfEntryPoint         uint32
+	BaseOfCode                  uint32
+	BaseOfData                  uint32
+	ImageBase                   uint32
+	SectionAlignment            uint32
+	FileAlignment               uint32
+	MajorOperatingSystemVersion uint16
+	MinorOperatingSystemVersion uint16
+	MajorImageVersion           uint16
+	MinorImageVersion           uint16
+	MajorSubsystemVersion       uint16
+	MinorSubsystemVersion       uint16
+	Win32VersionValue           uint32
+	SizeOfImage                 uint32
+	SizeOfHeaders               uint32
+	CheckSum                    uint32
+	Subsystem                   uint16
+	DllCharacteristics          uint16
+	SizeOfStackReserve          uint32
+	SizeOfStackCommit           uint32
+	SizeOfHeapReserve           uint32
+	SizeOfHeapCommit            uint32
+	LoaderFlags                 uint32
+	NumberOfRvaAndSizes         uint32
+}
+
 type OptionalHeader32 struct {
 	Magic                       uint16
 	MajorLinkerVersion          uint8
@@ -53,6 +92,73 @@ type OptionalHeader32 struct {
 	DataDirectory               [16]DataDirectory
 }
 
+func (o *OptionalHeader32) init(base optionalHeader32Base, dd []DataDirectory) {
+	o.Magic = base.Magic
+	o.MajorLinkerVersion = base.MajorLinkerVersion
+	o.MinorLinkerVersion = base.MinorLinkerVersion
+	o.SizeOfCode = base.SizeOfCode
+	o.SizeOfInitializedData = base.SizeOfInitializedData
+	o.SizeOfUninitializedData = base.SizeOfUninitializedData
+	o.AddressOfEntryPoint = base.AddressOfEntryPoint
+	o.BaseOfCode = base.BaseOfCode
+	o.BaseOfData = base.BaseOfData
+	o.ImageBase = base.ImageBase
+	o.SectionAlignment = base.SectionAlignment
+	o.FileAlignment = base.FileAlignment
+	o.MajorOperatingSystemVersion = base.MajorOperatingSystemVersion
+	o.MinorOperatingSystemVersion = base.MinorOperatingSystemVersion
+	o.MajorImageVersion = base.MajorImageVersion
+	o.MinorImageVersion = base.MinorImageVersion
+	o.MajorSubsystemVersion = base.MajorSubsystemVersion
+	o.MinorSubsystemVersion = base.MinorSubsystemVersion
+	o.Win32VersionValue = base.Win32VersionValue
+	o.SizeOfImage = base.SizeOfImage
+	o.SizeOfHeaders = base.SizeOfHeaders
+	o.CheckSum = base.CheckSum
+	o.Subsystem = base.Subsystem
+	o.DllCharacteristics = base.DllCharacteristics
+	o.SizeOfStackReserve = base.SizeOfStackReserve
+	o.SizeOfStackCommit = base.SizeOfStackCommit
+	o.SizeOfHeapReserve = base.SizeOfHeapReserve
+	o.SizeOfHeapCommit = base.SizeOfHeapCommit
+	o.LoaderFlags = base.LoaderFlags
+	o.NumberOfRvaAndSizes = base.NumberOfRvaAndSizes
+
+	copy(o.DataDirectory[:], dd)
+}
+
+type optionalHeader64Base struct {
+	Magic                       uint16
+	MajorLinkerVersion          uint8
+	MinorLinkerVersion          uint8
+	SizeOfCode                  uint32
+	SizeOfInitializedData       uint32
+	SizeOfUninitializedData     uint32
+	AddressOfEntryPoint         uint32
+	BaseOfCode                  uint32
+	ImageBase                   uint64
+	SectionAlignment            uint32
+	FileAlignment               uint32
+	MajorOperatingSystemVersion uint16
+	MinorOperatingSystemVersion uint16
+	MajorImageVersion           uint16
+	MinorImageVersion           uint16
+	MajorSubsystemVersion       uint16
+	MinorSubsystemVersion       uint16
+	Win32VersionValue           uint32
+	SizeOfImage                 uint32
+	SizeOfHeaders               uint32
+	CheckSum                    uint32
+	Subsystem                   uint16
+	DllCharacteristics          uint16
+	SizeOfStackReserve          uint64
+	SizeOfStackCommit           uint64
+	SizeOfHeapReserve           uint64
+	SizeOfHeapCommit            uint64
+	LoaderFlags                 uint32
+	NumberOfRvaAndSizes         uint32
+}
+
 type OptionalHeader64 struct {
 	Magic                       uint16
 	MajorLinkerVersion          uint8
@@ -84,6 +190,40 @@ type OptionalHeader64 struct {
 	LoaderFlags                 uint32
 	NumberOfRvaAndSizes         uint32
 	DataDirectory               [16]DataDirectory
+}
+
+func (o *OptionalHeader64) init(base optionalHeader64Base, dd []DataDirectory) {
+	o.Magic = base.Magic
+	o.MajorLinkerVersion = base.MajorLinkerVersion
+	o.MinorLinkerVersion = base.MinorLinkerVersion
+	o.SizeOfCode = base.SizeOfCode
+	o.SizeOfInitializedData = base.SizeOfInitializedData
+	o.SizeOfUninitializedData = base.SizeOfUninitializedData
+	o.AddressOfEntryPoint = base.AddressOfEntryPoint
+	o.BaseOfCode = base.BaseOfCode
+	o.ImageBase = base.ImageBase
+	o.SectionAlignment = base.SectionAlignment
+	o.FileAlignment = base.FileAlignment
+	o.MajorOperatingSystemVersion = base.MajorOperatingSystemVersion
+	o.MinorOperatingSystemVersion = base.MinorOperatingSystemVersion
+	o.MajorImageVersion = base.MajorImageVersion
+	o.MinorImageVersion = base.MinorImageVersion
+	o.MajorSubsystemVersion = base.MajorSubsystemVersion
+	o.MinorSubsystemVersion = base.MinorSubsystemVersion
+	o.Win32VersionValue = base.Win32VersionValue
+	o.SizeOfImage = base.SizeOfImage
+	o.SizeOfHeaders = base.SizeOfHeaders
+	o.CheckSum = base.CheckSum
+	o.Subsystem = base.Subsystem
+	o.DllCharacteristics = base.DllCharacteristics
+	o.SizeOfStackReserve = base.SizeOfStackReserve
+	o.SizeOfStackCommit = base.SizeOfStackCommit
+	o.SizeOfHeapReserve = base.SizeOfHeapReserve
+	o.SizeOfHeapCommit = base.SizeOfHeapCommit
+	o.LoaderFlags = base.LoaderFlags
+	o.NumberOfRvaAndSizes = base.NumberOfRvaAndSizes
+
+	copy(o.DataDirectory[:], dd)
 }
 
 const (


### PR DESCRIPTION
<< The PR is on my private fork, for internal review only >>

The debug/pe package assumes there are always 16 entries in []DataDirectory in OptionalHeader32/64 (ref pe.go)
	NumberOfRvaAndSizes         uint32
	DataDirectory               [16]DataDirectory
}

But that is not always the case, there could be less no of entries (PE signed linux kernel for example):
prashant@Pra-Work:~$ sudo pev /boot/vmlinuz-4.15.0-47-generic 
....
 Data-dictionary entries:	6
....

In such case, the parsing gives incorrect results. This changes aims to fix that by:
1. Determining type of optional header by looking at header magic instead of size.
2. Parsing optional header in 2 steps: 1. Fixed part and 2. Variable data directories part.

Testing:
1. Fixed existing test cases to reflect the change.
2. Added new file (linux kernel image) which has smaller number of data directories.

